### PR TITLE
Updated return type signature on SessionInformationManagementInterface

### DIFF
--- a/Api/SessionInformationManagementInterface.php
+++ b/Api/SessionInformationManagementInterface.php
@@ -26,7 +26,7 @@ interface SessionInformationManagementInterface
      * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
      * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
      * @throws \Magento\Framework\Exception\CouldNotSaveException
-     * @return array
+     * @return mixed
      */
     public function createNewPaymentSession(
         $cartId,
@@ -39,7 +39,7 @@ interface SessionInformationManagementInterface
      * @param string $email
      * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
      * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
-     * @return array
+     * @return mixed
      */
     public function createNewGuestPaymentSession(
         $cartId,


### PR DESCRIPTION
This module uses array as return type on SessionInformationManagementInterface methods, which breaks Swagger spec file generation, as array is not recognized as a class or base return type by Magento. Changing array to mixed fixes this issue without breaking any core payment functionality.

How to reproduce:
1. Set up a clean installation of Magento with OnTap Mastercard module
2. Browse to https://<host_name>/rest/all/schema?services=all

Expected output:
1. JSON schema loads correctly.

Actual output:
1. JSON schema generation fails because array is not recognized as a class or usable return type.
![Screenshot from 2020-07-27 23-25-02](https://user-images.githubusercontent.com/705308/88593866-7a914500-d060-11ea-8675-dda5451f8097.png)

Proposed fix:
Change return type annotation from array to mixed. This fixes the issue without breaking any functionality.