### PR TITLE
New Feature: Specify hosted checkout form locale

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -162,4 +162,9 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     {
         return (bool) $this->getValue('send_line_items', $storeId);
     }
+
+    public function getFormLocale($storeId = null)
+    {
+        return $this->getValue('form_locale', $storeId);
+    }
 }

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -163,6 +163,10 @@ class Config extends \Magento\Payment\Gateway\Config\Config
         return (bool) $this->getValue('send_line_items', $storeId);
     }
 
+    /**
+     * @param int|null $storeId
+     * @return string
+     */
     public function getFormLocale($storeId = null)
     {
         return $this->getValue('form_locale', $storeId);

--- a/Model/Ui/Hosted/ConfigProvider.php
+++ b/Model/Ui/Hosted/ConfigProvider.php
@@ -59,6 +59,7 @@ class ConfigProvider implements ConfigProviderInterface
                 self::METHOD_CODE => [
                     'merchant_username' => $this->config->getMerchantId(),
                     'component_url' => $this->config->getComponentUrl(),
+                    'form_locale' => $this->config->getFormLocale(),
                 ]
             ]
         ];

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -200,6 +200,11 @@
                         <config_path>payment/tns_hosted/webhook_url</config_path>
                         <comment>If left blank, will be chosen automatically</comment>
                     </field>
+                    <field id="form_locale" translate="label comment" type="text" sortOrder="82" showInDefault="1" showInWebsite="1" showInStore="0">
+                        <label>Form Locale</label>
+                        <config_path>payment/tns_hosted/form_locale</config_path>
+                        <comment>Override browser based locale by specifying a language identifier or IETF language tag e.g. en_US, es, fr_CA.</comment>
+                    </field>
                     <field id="api_gateway" translate="label" type="select" sortOrder="89" showInDefault="1" showInWebsite="1" showInStore="0">
                         <label>Gateway</label>
                         <source_model>OnTap\MasterCard\Model\Adminhtml\Source\Gateway</source_model>

--- a/view/frontend/web/js/view/payment/hosted-adapter.js
+++ b/view/frontend/web/js/view/payment/hosted-adapter.js
@@ -35,12 +35,15 @@ define([
             node.setAttribute('data-cancel', 'window.tnsCancelCallback');
             node.setAttribute('data-complete', 'window.tnsCompletedCallback');
         },
-        configureApi: function (merchant, sessionId, sessionVersion) {
+        configureApi: function (merchant, sessionId, sessionVersion, formLocale) {
             Checkout.configure({
                 merchant: merchant,
                 session: {
                     id: sessionId,
                     version: sessionVersion
+                },
+                interaction: {
+                    locale: formLocale
                 }
             });
         },

--- a/view/frontend/web/js/view/payment/method-renderer/tns-hosted.js
+++ b/view/frontend/web/js/view/payment/method-renderer/tns-hosted.js
@@ -122,7 +122,8 @@ define(
                         paymentAdapter.configureApi(
                             config.merchant_username,
                             session[0],
-                            session[1]
+                            session[1],
+                            config.form_locale
                         );
 
                         paymentAdapter.showPayment();


### PR DESCRIPTION
This PR allows setting the locale for the hosted checkout form from Payment Settings in adminhtml.

![Screenshot from 2020-07-28 14-54-52](https://user-images.githubusercontent.com/705308/88669650-71e25280-d0e4-11ea-8911-7ec1952511b3.png)

![Screenshot from 2020-07-28 14-55-27](https://user-images.githubusercontent.com/705308/88669668-79096080-d0e4-11ea-8e0d-f87840018fc1.png)
