### PR TITLE
Detailed a race condition bug very thoroughly

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/tns-hpf.js
+++ b/view/frontend/web/js/view/payment/method-renderer/tns-hpf.js
@@ -182,6 +182,10 @@ define(
                 this.isPlaceOrderActionAllowed(false);
                 this.buttonTitle(this.buttonTitleDisabled);
 
+                // If this is executed _prior_ to the `hpf-cc-form.html` template having been loaded and rendered,
+                // the inputs will not currently exist and hence will not function as intended. It is easy enough
+                // to confirm when this occurs as those inputs have a `readonly` attribute so they won't accept any input.
+
                 PaymentSession.configure({
                     fields: this.getCardFields(),
                     frameEmbeddingMitigation: ['x-frame-options'],

--- a/view/frontend/web/template/payment/hpf-cc-form.html
+++ b/view/frontend/web/template/payment/hpf-cc-form.html
@@ -14,6 +14,17 @@
   ~ limitations under the License.
   -->
 
+<!--
+    BUG: Race condition loading JS and templates.
+
+    There is no guarantee that the inputs in this template have been rendered _prior_ to the required JS being triggered in `tns-hpf.js::paymentAdapterLoaded()`,
+    it all depends on whether or not the payment adapter was loaded first or this template.
+
+    This is trivial to simulate by adding a rule to `pub/static/.htaccess` that rewrites this file to a version of `pub/static.php` with a call to `sleep($seconds)` at the top.
+    For example, adding the rule `RewriteRule ^(.*)tns-hpf.html ../static-with-delay.php?resource=$0 [L]` immediately after `RewriteRule ^version.+?/(.+)$ $1 [L]` would work acceptably.
+    Obviously you would also need to create the relevant `pub/static-with-delay.php` file.
+-->
+
 <fieldset data-bind="attr: {class: 'fieldset payment items ccard ' + getCode(), id: 'payment_form_' + getCode()}">
     <div class="field number required">
         <label data-bind="attr: {for: getCode() + '_cc_number'}" class="label">

--- a/view/frontend/web/template/payment/tns-hpf.html
+++ b/view/frontend/web/template/payment/tns-hpf.html
@@ -36,7 +36,23 @@
             'transparent':{
                 'context': context()
             }, 'validation':[]}">
+
+            <!--
+                One _potential_ solution to the bug is to add an `afterRender` callback to the template binding. You will have
+                to also swap out for a non-virtual element to be able to attach this binding.
+
+                For example:
+                `<div data-bind="template: { name: 'OnTap_MasterCard/payment/hpf-cc-form' }, afterRender: loadAdapter"></div>`
+
+                This would effectively guarantee that the inputs have been rendered prior to the required JS triggering.
+
+                Disclaimer: This is only an example suggestion, I do not have intimate knowledge of the inner workings of this module.
+                Additionally, the `paymentAdapterLoaded()` method looks like it may be more suitable than the `loadAdapter()` method,
+                but I am not certain if the required JS in `config.component_url` will still function correctly with multiple calls to
+                `PaymentSession.configure(...)`.
+            -->
             <!-- ko template: 'OnTap_MasterCard/payment/hpf-cc-form' --><!-- /ko -->
+
             <!-- ko if: (isVaultEnabled())-->
             <div class="field choice">
                 <input type="checkbox"


### PR DESCRIPTION
This pull request simply outlines a race condition bug in more than enough detail for a fix to me implemented. I am only submitting this as a pull request because it appears that the ability to report issues for this repository has been disabled.

In summary, there is no guarantee that the inputs in the `hpf-cc-form.html` template have been rendered _prior_ to the required JS being triggered in `tns-hpf.js::paymentAdapterLoaded()`, it all depends on whether or not the payment adaptor was loaded first or that template.

I have even provided instructions on how to simulate the race condition.

See the changes for full details and let me know if you have any questions.