### PR TITLE
Fix MpgsHostedLogger dependencies injection

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -25,7 +25,7 @@
 
     <virtualType name="MpgsHostedLogger" type="Magento\Payment\Model\Method\Logger">
         <arguments>
-            <argument name="config" xsi:type="object">TnsHpfConfig</argument>
+            <argument name="config" xsi:type="object">TnsHostedConfig</argument>
         </arguments>
     </virtualType>
 


### PR DESCRIPTION
The `TnsHostedConfig` virtual type should be injected for the `MpgsHostedLogger` in order to read the right configuration