### PR TITLE
MPGS-798: "Invalid credentials" error message shown when trying to sa…

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,6 +18,8 @@
     <preference for="OnTap\MasterCard\Api\SessionInformationManagementInterface" type="OnTap\MasterCard\Model\SessionInformationManagement" />
     <preference for="OnTap\MasterCard\Api\VerifyPaymentFlagInterface" type="OnTap\MasterCard\Model\VerifyPaymentFlag" />
 
+    <type name="OnTap\MasterCard\Gateway\Http\Client\Adapter\Rest" shared="false" />
+
     <type name="OnTap\MasterCard\Model\System\Config\Backend\Cert">
         <arguments>
             <argument name="resource" xsi:type="object">Magento\Config\Model\ResourceModel\Config\Data</argument>


### PR DESCRIPTION
…ve module settings even for correct credentials

Fixes an issue where OnTap\MasterCard\Gateway\Http\Client\Adapter\Rest is being re-used among all payment clients causing them to reuse curl resource handle and improperly configuring the client with mixed parameters from different methods.

This only happens when different APIs are being contacted in the same request i.e. admin config values validation.